### PR TITLE
Bug #54: blocking queue needed after video encoder

### DIFF
--- a/src/depthai_wrappers/teleop_wrapper.py
+++ b/src/depthai_wrappers/teleop_wrapper.py
@@ -55,17 +55,19 @@ class TeleopWrapper(Wrapper):  # type: ignore[misc]
 
     def create_encoders(self, pipeline: dai.Pipeline) -> dai.Pipeline:
         profile = dai.VideoEncoderProperties.Profile.H264_MAIN
+        bitrate = 4000
+        numBFrames = 0  # gstreamer recommends 0 B frames
         self.left_encoder = pipeline.create(dai.node.VideoEncoder)
         self.left_encoder.setDefaultProfilePreset(self.cam_config.fps, profile)
         self.left_encoder.setKeyframeFrequency(self.cam_config.fps)  # every 1s
-        self.left_encoder.setNumBFrames(0)  # gstreamer recommends 0 B frames
-        self.left_encoder.setBitrateKbps(4000)
+        self.left_encoder.setNumBFrames(numBFrames)
+        self.left_encoder.setBitrateKbps(bitrate)
 
         self.right_encoder = pipeline.create(dai.node.VideoEncoder)
         self.right_encoder.setDefaultProfilePreset(self.cam_config.fps, profile)
         self.right_encoder.setKeyframeFrequency(self.cam_config.fps)  # every 1s
-        self.right_encoder.setNumBFrames(0)  # gstreamer recommends 0 B frames
-        self.right_encoder.setBitrateKbps(4000)
+        self.right_encoder.setNumBFrames(numBFrames)
+        self.right_encoder.setBitrateKbps(bitrate)
 
         return pipeline
 
@@ -83,3 +85,10 @@ class TeleopWrapper(Wrapper):  # type: ignore[misc]
         pipeline = self.create_output_streams(pipeline)
 
         return self.link_pipeline(pipeline)
+
+    def create_queues(self) -> Dict[str, dai.DataOutputQueue]:
+        # config for video: https://docs.luxonis.com/projects/api/en/latest/components/device/#output-queue-maxsize-and-blocking
+        queues: Dict[str, dai.DataOutputQueue] = {}
+        for name in ["left", "right"]:
+            queues[name] = self.device.getOutputQueue(name, maxSize=10, blocking=True)
+        return queues

--- a/src/depthai_wrappers/wrapper.py
+++ b/src/depthai_wrappers/wrapper.py
@@ -118,7 +118,6 @@ class Wrapper(ABC):
         self.right.setBoardSocket(right_socket)
         self.right.setResolution(dai.ColorCameraProperties.SensorResolution.THE_1440X1080)
         self.right.setIspScale(*self.cam_config.isp_scale)
-
         # self.cam_config.set_undistort_resolution(self.left.getIspSize())
 
         if self.cam_config.exposure_params is not None:
@@ -151,11 +150,9 @@ class Wrapper(ABC):
 
         return pipeline
 
+    @abstractmethod
     def create_queues(self) -> Dict[str, dai.DataOutputQueue]:
-        queues: Dict[str, dai.DataOutputQueue] = {}
-        for name in ["left", "right"]:
-            queues[name] = self.device.getOutputQueue(name, maxSize=1, blocking=False)
-        return queues
+        pass
 
     def create_manipRectify(
         self,
@@ -170,9 +167,11 @@ class Wrapper(ABC):
             try:
                 mesh, meshWidth, meshHeight = self.get_mesh(cam_name)
                 manipRectify.setWarpMesh(mesh, meshWidth, meshHeight)
+
             except Exception as e:
                 self._logger.error(e)
                 exit()
+
         manipRectify.setMaxOutputFrameSize(resolution[0] * resolution[1] * 3)
 
         return manipRectify
@@ -285,7 +284,7 @@ class Wrapper(ABC):
         device_calibration_backup_file = Path("./CALIBRATION_BACKUP_" + now + ".json")
         deviceCalib = self.device.readCalibration()
         deviceCalib.eepromToJsonFile(device_calibration_backup_file)
-        self._logger.info("Backup of device calibration saved to", device_calibration_backup_file)
+        self._logger.info(f"Backup of device calibration saved to {device_calibration_backup_file}")
 
         os.environ["DEPTHAI_ALLOW_FACTORY_FLASHING"] = "235539980"
 


### PR DESCRIPTION
using a blocking queue for the teleop since we don't want to loose h264 frames