### PR TITLE
Update RAM initialization

### DIFF
--- a/pollen_vision/pollen_vision/vision_models/object_detection/recognize_anything/RAM_wrapper.py
+++ b/pollen_vision/pollen_vision/vision_models/object_detection/recognize_anything/RAM_wrapper.py
@@ -40,6 +40,9 @@ class RAM_wrapper:
 
         self._checkpoint_path = get_checkpoint_path(checkpoint_name)
 
+        if objects_descriptions_filename.endswith(".json"):
+            objects_descriptions_filename = objects_descriptions_filename[: -len(".json")]
+
         try:
             object_description = json.load(
                 open(f"{objects_descriptions_folder_path}/{objects_descriptions_filename}.json", "rb")


### PR DESCRIPTION
- Split the objects_descriptions_file_path argument  into two arguments: objects_descriptions_filename and objects_descriptions_folder_path. This should make the process of loading a description file easier. The init method will try to load the file with name objects_descriptions_filename at the objects_descriptions_folder_path. The default value of objects_descriptions_folder_path is the [objects_descriptions folder](https://github.com/pollen-robotics/pollen-vision/tree/58-refactor-pollen-vision/pollen_vision/pollen_vision/vision_models/object_detection/recognize_anything/objects_descriptions) of the repo
- Raise errors if model checkpoint or description file are not found
- Add open_set_categories public attribute

Close #89.